### PR TITLE
15 minutes instead of 15 seconds 🙈

### DIFF
--- a/src/Events/ready.ts
+++ b/src/Events/ready.ts
@@ -55,7 +55,7 @@ export const event: Event = new Event({
           if (
             SnowflakeUtil.deconstruct(interaction.id).timestamp -
               BigInt(+new Date()) >
-            -(15 * 1000)
+            -(15 * 60 * 1000)
           ) {
             // interaction too old to edit
             await interaction.sendEmbed(


### PR DESCRIPTION
forgor to multiply by 60, which means that if a restart takes > 15 seconds, it won't update it's message anymore :|